### PR TITLE
Configurable Server Jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Otherwise, it must bind to port `25575`.
 
 1. Change the server type to Fabric
 2. Upload stomloader to the `mods/` folder.
-3. Upload your custom server JAR to the root directory, and rename it to `airbrush.jar`.
+3. Upload your custom server JAR to the root directory, and rename it to `airbrush.jar` or configure the `serverJar` option in `stomloader.properties`.
 4. You're good to go!
 
 Keep in note that stomloader will automatically download and start ViaProxy alongside the server for version support.<br />

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
 	loader_version=0.16.0
 
 # Mod Properties
-	mod_version = 0.2.0
+	mod_version = 0.3.0
 	maven_group = me.honkling
 	archives_base_name = stomloader
 

--- a/src/main/java/me/honkling/stomloader/StomLoader.java
+++ b/src/main/java/me/honkling/stomloader/StomLoader.java
@@ -25,11 +25,11 @@ public class StomLoader implements DedicatedServerModInitializer {
         }
 
         if (!serverJar.exists()) {
-            System.err.printf("The JAR file %s could not be found.", serverJar.getAbsolutePath());
+            System.err.printf("The JAR file `%s` could not be found.", serverJar.getAbsolutePath());
             return;
         }
 
-        System.out.printf("Found the %s JAR file. Running now.%n", serverJar.getAbsolutePath());
+        System.out.printf("Found the `%s` JAR file. Running now.%n", serverJar.getAbsolutePath());
         Process viaProxy = null;
         Process process = null;
 
@@ -45,6 +45,7 @@ public class StomLoader implements DedicatedServerModInitializer {
             var memory = System.getenv("SERVER_RAM");
             var processBuilder = new ProcessBuilder(getExecutablePath(), "-jar", "-Xms" + memory, "-Xmx" + memory, serverJar.getAbsolutePath())
                     .inheritIO();
+            processBuilder.directory(serverJar.getParentFile());
 
             if (viaProxy != null)
                 processBuilder.environment().remove("SERVER_PORT");

--- a/src/main/java/me/honkling/stomloader/StomLoader.java
+++ b/src/main/java/me/honkling/stomloader/StomLoader.java
@@ -7,22 +7,16 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 public class StomLoader implements DedicatedServerModInitializer {
-    private static File SERVER = new File("airbrush.jar");
+    private static File serverJar = new File("airbrush.jar");
     private static boolean enableViaProxy = false;
     private static String[] viaProxyArgs = new String[] {"cli", "--bind-address", "0.0.0.0:25575"};
 
     @Override public void onInitializeServer() {}
     public static void main() {
-        if (!SERVER.exists()) {
-            System.err.println("The Airbrush JAR file could not be found. Please upload it at `airbrush.jar`.");
-            return;
-        }
-
         try {
             initializeProperties();
         } catch (IOException exception) {
@@ -30,7 +24,12 @@ public class StomLoader implements DedicatedServerModInitializer {
             exception.printStackTrace();
         }
 
-        System.out.println("Found the Airbrush JAR file. Running now.");
+        if (!serverJar.exists()) {
+            System.err.printf("The JAR file %s could not be found.", serverJar.getAbsolutePath());
+            return;
+        }
+
+        System.out.printf("Found the %s JAR file. Running now.%n", serverJar.getAbsolutePath());
         Process viaProxy = null;
         Process process = null;
 
@@ -44,7 +43,7 @@ public class StomLoader implements DedicatedServerModInitializer {
 
         try {
             var memory = System.getenv("SERVER_RAM");
-            var processBuilder = new ProcessBuilder(getExecutablePath(), "-jar", "-Xms" + memory, "-Xmx" + memory, SERVER.getAbsolutePath())
+            var processBuilder = new ProcessBuilder(getExecutablePath(), "-jar", "-Xms" + memory, "-Xmx" + memory, serverJar.getAbsolutePath())
                     .inheritIO();
 
             if (viaProxy != null)
@@ -54,7 +53,7 @@ public class StomLoader implements DedicatedServerModInitializer {
             Runtime.getRuntime().addShutdownHook(new Thread(process::destroy));
             process.waitFor();
         } catch (IOException exception) {
-            System.err.println("An error occurred when running Airbrush.");
+            System.err.println("An error occurred when running stomloader.");
             exception.printStackTrace();
         } catch (InterruptedException exception) {
             System.out.println("Shutting down...");
@@ -88,7 +87,9 @@ public class StomLoader implements DedicatedServerModInitializer {
                 enableViaProxy = value.equalsIgnoreCase("true");
             else if (key.equalsIgnoreCase("viaproxyArgs"))
                 viaProxyArgs = value.split(" ");
-            else System.err.println("Found unexpected key in stomloader.properties: " + key);
+            else if (key.equalsIgnoreCase("serverJar")) {
+                serverJar = new File(value);
+            } else System.err.println("Found unexpected key in stomloader.properties: " + key);
         }
     }
 

--- a/src/main/resources/stomloader.properties
+++ b/src/main/resources/stomloader.properties
@@ -1,2 +1,3 @@
+serverJar=airbrush.jar
 viaproxy=true
 viaproxyArgs=cli --bind-address 0.0.0.0:25575


### PR DESCRIPTION
This PR allows users to configure the name of the server jar they want to use, rather than it always using `airbrush.jar`. By default, it will still use that unless the user changes it in the properties file.